### PR TITLE
Make footer copyright date self updating.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,7 +47,7 @@
         <footer class="footer">
           {% include svg-icons.html %}
 	  <br /><br />
-          (c) 2016 LineageOS Project <br />We are currently not accepting monetary donations. This message will be removed when there is an official method to help fund the project.
+	  &copy; {{ 'now' | date: "%Y" }} LineageOS Project <br />We are currently not accepting monetary donations. This message will be removed when there is an official method to help fund the project.
       </div>
     </div>
 


### PR DESCRIPTION
- uses the real copyright symbol
- year will always be accurate after each build