### PR TITLE
Add site url, fixes RSS feeds

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ google_analytics: UA-89627920-1
 
 # Your website URL (e.g. http://barryclark.github.io or http://www.barryclark.co)
 # Used for Sitemap.xml and your RSS feed
-url:
+url: https://lineageos.org
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)


### PR DESCRIPTION
The XML feed templates prefix the site URL, e.g. here:

https://github.com/LineageOS/www/blob/39dbf0bce5798aebe163ef1b94730a7c028793b6/feed.xml#L15

However, the URL wasn't set and the feeds contained just relative paths as links, which is not a valid RSS feed.