### PR TITLE
Changes to RSS feeds and added proper ATOM feed

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" />
 
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
+    <link rel="alternate" type="application/atom+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.atom" />
     <link rel="shortcut icon" href="{{ site.baseurl }}/images/logo.png">
 
   </head>

--- a/feed.atom
+++ b/feed.atom
@@ -1,0 +1,30 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>LineageOS</title>
+    <subtitle>LineageOS Android Distribution - Blog</subtitle>
+    <id>{{ site.url }}/</id>
+    <author>  
+      <name>LineageOS team</name>
+    </author>
+    <link rel="self" href="{{ site.url }}/feed.atom" />
+    <logo>{{ site.url }}/assets/logo.png</logo>
+    <updated>{{ site.time | date_to_xmlschema }}</updated>
+    {% for post in site.categories.blog %}
+        <entry>
+            <title>{{ post.title | xml_escape }}</title>
+            <summary> {{ post.excerpt  | xml_escape }}</summary>
+            <author>
+              <name>{{ post.author | xml_escape }}</name>
+            </author>
+            <updated>{{ post.date | date_to_xmlschema }}</updated>
+            <link href="{{ post.url | prepend: site.url }}" />
+            <id>{{ post.url | prepend: site.url }}</id>
+            <content type="html">
+                {{ post.content | escape }}
+            </content>
+        </entry>
+    {% endfor %}
+</feed>

--- a/feed.xml
+++ b/feed.xml
@@ -2,16 +2,22 @@
 layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0">
   <channel>
     <title>LineageOS</title>
-    <description>LineageOS Android Dstribution - Blog</description>
+    <description>LineageOS Android Distribution - Blog</description>
     <link>{{ site.url }}</link>
+    <image>
+      <url>{{ site.url }}/images/logo.png</url>
+      <title>LineageOS</title>
+      <link>{{ site.url }}</link>
+    </image>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     {% for post in site.categories.blog %}
         <item>
             <title>{{ post.title | xml_escape }}</title>
             <description> {{ post.excerpt  | xml_escape }}</description>
-            <pubDate>{{ post.date | date_to_xmlschema }}</pubDate>
+            <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
             <link>{{ post.url | prepend: site.url }}</link>
             <guid isPermaLink="true">{{ post.url | prepend: site.url }}</guid>
         </item>


### PR DESCRIPTION
1. Removed atom related stuff from the rss feed so it validates better with https://validator.w3.org/feed/#validate_by_input - still not perfect
2. Created separate atom feed to contain all the atom like syntax previously on the rss feed, again, it validates as proper atom feed with https://validator.w3.org/feed/#validate_by_input but since I have less experience with atom feeds there are few issues
3. Added atom feed to the page head element on the default layout so it can be found

I created separate atom feed if someone already has a service relying on the current rss/atom feed so those aren't that likely to break, but I fixed the date formatting since rss spec uses different time and date format compared to atom feeds

I did this fork because I would like to host a Mastodon bot which would publish content automatically from the rss feed to an unofficial Mastodon bot profile (and I would mark it clearly as unofficial to avoid confusion). This bot would collect first few hundred charachters from each atom entry content and after that link to the original source, so users could more easily follow their points of interests. The modifications took way longer than I expected so I have to leave them as is and get some sleep, but at least both feeds do now validate with the w3.org validator